### PR TITLE
Always show full table from callback

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -80,7 +80,9 @@ function (cb::GeoOptDefaultCallback)(optim_state, geoopt_state)
     pretty_table(stdout, reshape(getindex.(fields, 3), 1, length(fields));
                  table_format, title, show_column_labels,
                  column_labels=getindex.(fields, 1),
-                 fixed_data_column_widths=getindex.(fields, 2))
+                 fixed_data_column_widths=getindex.(fields, 2),
+                 # show full table regardless of displaysize
+                 fit_table_in_display_horizontally=false)
     cb.always_show_header && println(stdout)
 
     flush(stdout)


### PR DESCRIPTION
Otherwise it looks like this when redirecting stdout to a file: (quite ugly :D)

```
┌─────┬─────────────────┬───────────┬─────────────┬─────────────┬──────────┬────
│   n │          Energy │ log10(ΔE) │  max(Force) │ max(Virial) │ Pressure │   ⋯
├─────┼─────────────────┼───────────┼─────────────┼─────────────┼──────────┼────
│   1 │ -120.2653130294 │           │ 1.30883e-13 │  0.00563863 │    0.003 │   ⋯
└─────┴─────────────────┴───────────┴─────────────┴─────────────┴──────────┴────
                                                                1 column omitted
```